### PR TITLE
Upgrade & Fix Compile

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -210,6 +210,7 @@ tasks {
 dependencies {
   implementation("org.aya-prover", "ide-lsp", ayaVersion) {
     exclude("org.aya-prover.upstream", "ij-parsing-core")
+    exclude("org.aya-prover.upstream", "ij-util-text")
   }
   testImplementation(kotlin("test-junit"))
 }

--- a/gradle/deps.properties
+++ b/gradle/deps.properties
@@ -1,3 +1,3 @@
 version.project=0.0.1-SNAPSHOT
-version.aya=0.29-SNAPSHOT
+version.aya=0.29
 version.aya-upstream=0.0.12

--- a/src/main/java/org/aya/intellij/language/AyaIJParserImpl.java
+++ b/src/main/java/org/aya/intellij/language/AyaIJParserImpl.java
@@ -29,7 +29,7 @@ import java.util.Arrays;
 
 public record AyaIJParserImpl(@NotNull Project project, @NotNull Reporter reporter) implements GenericAyaParser {
   @Override public @NotNull Expr expr(@NotNull String code, @NotNull SourcePos overridingSourcePos) {
-    var producer = new AyaProducer(code, Either.right(overridingSourcePos), reporter);
+    var producer = new AyaProducer(Either.right(overridingSourcePos), reporter);
     var expr = (AyaPsiElement) AyaPsiFactory.expr(project, code);
     return producer.expr(new ASTGenericNode(expr.getNode()));
   }
@@ -43,7 +43,7 @@ public record AyaIJParserImpl(@NotNull Project project, @NotNull Reporter report
       // TODO: support literate mode
       var code = ayaFile.getText();
       var updated = new SourceFile(codeFile.display(), codeFile.underlying(), code);
-      var producer = new AyaProducer(code, Either.left(updated), reporter);
+      var producer = new AyaProducer(Either.left(updated), reporter);
       return producer.program(new ASTGenericNode(ayaFile.getNode())).getLeftValue();
     });
   }


### PR DESCRIPTION
This PR upgrades Aya from version `0.29-SNAPSHOT` to `0.29` and fixes `LinkageError`.